### PR TITLE
Fixed port settings

### DIFF
--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -214,7 +214,7 @@ spec:
         - name: CONFIGURATION_SERVICE
           value: 'http://configuration-service:8080'
         - name: EVENTBROKER
-          value: 'http://localhost:8081/event'
+          value: 'http://localhost:8082/event'
         - name: API
           value: 'ws://api-service:8080/websocket'
         - name: POD_NAMESPACE
@@ -239,6 +239,8 @@ spec:
             value: 'sh.keptn.event.monitoring.configure'
           - name: PUBSUB_RECIPIENT
             value: '127.0.0.1'
+          - name: RCV_PORT
+            value: '8082'
       serviceAccountName: keptn-prometheus-service
 ---
 apiVersion: v1

--- a/main.go
+++ b/main.go
@@ -114,7 +114,7 @@ func Handler(rw http.ResponseWriter, req *http.Request) {
 		}
 		defer resp.Body.Close()
 
-		if resp.StatusCode < 200 && resp.StatusCode > 299 {
+		if resp.StatusCode < 200 || resp.StatusCode > 299 {
 			logger.Error(fmt.Sprintf("Could not process cloud event: Handler returned status %s", resp.Status))
 			rw.WriteHeader(500)
 		} else {

--- a/main.go
+++ b/main.go
@@ -114,8 +114,8 @@ func Handler(rw http.ResponseWriter, req *http.Request) {
 		}
 		defer resp.Body.Close()
 
-		if resp.StatusCode != 202 {
-			logger.Error(fmt.Sprintf("Could not send cloud event: %s", err.Error()))
+		if resp.StatusCode < 200 && resp.StatusCode > 299 {
+			logger.Error(fmt.Sprintf("Could not process cloud event: Handler returned status %s", resp.Status))
 			rw.WriteHeader(500)
 		} else {
 			logger.Debug("event successfully sent to port 8081")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -29,10 +29,8 @@ func GetEventBrokerURL() (string, error) {
 	if err != nil {
 		eventBrokerURL = "http://localhost:8081/event"
 		return "", fmt.Errorf("Could not parse EVENTBROKER URL %s: %s. Using default: %s", os.Getenv(eventbroker), err.Error(), eventBrokerURL)
-	} else {
-		eventBrokerURL = endpoint.String()
-		return "", fmt.Errorf("EVENTBROKER URL: %s", eventBrokerURL)
 	}
+	eventBrokerURL = endpoint.String()
 	return eventBrokerURL, nil
 }
 


### PR DESCRIPTION
The prometheus-service also listens on Port 8081, which is the default port of the distributor. This lead to the distributor crashing because that port was already in use. This PR sets the port for the distributor to 8082