### PR TITLE
Added scrape job config for primary deployment

### DIFF
--- a/eventhandling/alertEvent.go
+++ b/eventhandling/alertEvent.go
@@ -101,7 +101,7 @@ func createAndSendCE(problemData keptnevents.ProblemEventData, shkeptncontext st
 	event := cloudevents.NewEvent()
 	event.SetID(uuid.New().String())
 	event.SetTime(time.Now())
-	event.SetType(keptnevents.ProblemEventType)
+	event.SetType(keptnevents.ProblemOpenEventType)
 	event.SetSource(source.String())
 	event.SetExtension("shkeptncontext", shkeptncontext)
 	event.SetDataContentType(cloudevents.ApplicationJSON)

--- a/eventhandling/configureEvent.go
+++ b/eventhandling/configureEvent.go
@@ -582,6 +582,7 @@ func createScrapeJobConfig(scrapeConfig *prometheusconfig.ScrapeConfig, config *
 		scrapeConfigName = scrapeConfigName + "-canary"
 		scrapeEndpoint = service + "-canary." + project + "-" + stage + ":80"
 	} else if isPrimary {
+		scrapeConfigName = scrapeConfigName + "-primary"
 		scrapeEndpoint = service + "-primary." + project + "-" + stage + ":80"
 	} else {
 		scrapeEndpoint = service + "." + project + "-" + stage + ":80"

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
 	github.com/hashicorp/serf v0.8.3 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.6.3-0.20201203142252-6e5e0dca0b12
+	github.com/keptn/go-utils v0.6.3-0.20201217115623-17e6dc4eb089
 	github.com/keptn/kubernetes-utils v0.1.0
 	github.com/prometheus/common v0.9.1
 	github.com/prometheus/prometheus v0.0.0-20200326161412-ae041f97cfc6

--- a/go.sum
+++ b/go.sum
@@ -469,6 +469,8 @@ github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa
 github.com/keptn/go-utils v0.6.1-compat.0.20200414111241-846f2becaf21/go.mod h1:aDNFm3olvCZd7AE6/Xyir4g5Mw6E89mjhKt0zoJHC6g=
 github.com/keptn/go-utils v0.6.3-0.20201203142252-6e5e0dca0b12 h1:jAV19GHP1TckQ+69eP7ziLbHDs73kZloqyQ3V9skSco=
 github.com/keptn/go-utils v0.6.3-0.20201203142252-6e5e0dca0b12/go.mod h1:jD+ZvrkwYyDMgeKANzVZsBSYgjYQxTJvxw/RB3vYFAE=
+github.com/keptn/go-utils v0.6.3-0.20201217115623-17e6dc4eb089 h1:0AhEa9KHZHaC2fNeK/CAwanYUN17wzu7+TgZhbTn9X0=
+github.com/keptn/go-utils v0.6.3-0.20201217115623-17e6dc4eb089/go.mod h1:SmTTNxBonQXC4/nxkqAWtVm4WjqEfu8r7EPQe8LZ1/Y=
 github.com/keptn/kubernetes-utils v0.1.0 h1:CJxvb710Dk3bJc5CxnMGdmkiJkcstwq1+h3WIvnt8+E=
 github.com/keptn/kubernetes-utils v0.1.0/go.mod h1:YoWRuV28Guz5/mzjo9jVxtMsWAEn0MDXwxK/ScAQlZc=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -535,6 +537,8 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.2.2 h1:dxe5oCinTXiTIcfgmZecdCzPmAJKd46KsCWc35r0TV4=
+github.com/mitchellh/mapstructure v1.2.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=


### PR DESCRIPTION
The name for the scrape jobs of the direct deployment and the proary deployment were the same and overwrote each other. 
Also, it turned out that SLI queries were still retrieved from a ConfigMap, instead of the `prometheus/sli.yaml` file.
This is fixed with this PR

Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>