### PR TITLE
Fix distributor image and resource requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ The *prometheus-service* is a [Keptn](https://keptn.sh) service that is responsi
 Please always double check the version of Keptn you are using compared to the version of this service, and follow the compatibility matrix below.
 
 
-| Keptn Version    | [Prometheus Service Image](https://hub.docker.com/r/keptn/prometheus-service/tags) |
+| Keptn Version    | [Prometheus Service Image](https://hub.docker.com/r/keptncontrib/prometheus-service/tags) |
 |:----------------:|:----------------------------------------:|
-|       0.5.x      | keptn/prometheus-service:0.2.0  |
-|       0.6.x      | keptn/prometheus-service:0.3.0  |
-|       0.6.1      | keptn/prometheus-service:0.3.2  |
-|       0.6.2      | keptn/prometheus-service:0.3.4  |
-|       0.7.0, 0.7.1      | keptn/prometheus-service:0.3.5  |
-|       0.7.2      | keptn/prometheus-service:0.3.6  |
+|       0.5.x      | keptncontrib/prometheus-service:0.2.0  |
+|       0.6.x      | keptncontrib/prometheus-service:0.3.0  |
+|       0.6.1      | keptncontrib/prometheus-service:0.3.2  |
+|       0.6.2      | keptncontrib/prometheus-service:0.3.4  |
+|   0.7.0, 0.7.1   | keptncontrib/prometheus-service:0.3.5  |
+|       0.7.2      | keptncontrib/prometheus-service:0.3.6  |
+|   0.8.0-alpha    | keptncontrib/prometheus-service:0.4.0-alpha  |
 
 # Installation
 

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -198,7 +198,7 @@ spec:
     spec:
       containers:
       - name: prometheus-service
-        image: keptncontrib/prometheus-service:latest
+        image: keptncontrib/prometheus-service:0.3.7-dev
         ports:
         - containerPort: 8080
         resources:
@@ -222,16 +222,16 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
       - name: distributor
-        image: keptn/distributor:latest
+        image: keptn/distributor:0.8.0-alpha # ToDo: change to 0.8.0 once final
         ports:
           - containerPort: 8080
         resources:
           requests:
-            memory: "32Mi"
-            cpu: "50m"
+            memory: "16Mi"
+            cpu: "25m"
           limits:
             memory: "128Mi"
-            cpu: "500m"
+            cpu: "250m"
         env:
           - name: PUBSUB_URL
             value: 'nats://keptn-nats-cluster'

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -2,7 +2,7 @@ apiVersion: skaffold/v1beta13
 kind: Config
 build:
   artifacts:
-    - image: keptn/prometheus-service
+    - image: keptncontrib/prometheus-service
       docker:    # 	beta describes an artifact built from a Dockerfile.
         dockerfile: Dockerfile
         buildArgs:


### PR DESCRIPTION
This PR ensures that the correct distributor image is used for Keptn 0.8.0-alpha, as well as change the docker org to keptncontrib (needed after PR https://github.com/keptn-contrib/prometheus-service/pull/78)