### PR TITLE
Adaptations to support the auto-remediation UC

### DIFF
--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -130,11 +130,11 @@ spec:
       labels:
         run: prometheus-service
         app.kubernetes.io/name: prometheus-service
-        app.kubernetes.io/version: 0.6.1
+        app.kubernetes.io/version: latest
     spec:
       containers:
         - name: prometheus-service
-          image: keptncontrib/prometheus-service:0.6.1
+          image: keptncontrib/prometheus-service:latest
           ports:
             - containerPort: 8080
           resources:
@@ -178,7 +178,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
         - name: distributor
-          image: keptn/distributor:0.8.4
+          image: keptn/distributor:0.9.2
           ports:
             - containerPort: 8080
           resources:

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -130,11 +130,11 @@ spec:
       labels:
         run: prometheus-service
         app.kubernetes.io/name: prometheus-service
-        app.kubernetes.io/version: latest
+        app.kubernetes.io/version: 0.6.3-dev-PR-177.202110010812
     spec:
       containers:
         - name: prometheus-service
-          image: keptncontrib/prometheus-service:latest
+          image: keptncontrib/prometheus-service:0.6.3-dev-PR-177.202110010812
           ports:
             - containerPort: 8080
           resources:

--- a/eventhandling/alertEvent.go
+++ b/eventhandling/alertEvent.go
@@ -3,7 +3,6 @@ package eventhandling
 import (
 	"encoding/json"
 	"fmt"
-	keptnevents "github.com/keptn/go-utils/pkg/lib"
 	"github.com/keptn/go-utils/pkg/lib/keptn"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"net/http"
@@ -16,6 +15,8 @@ import (
 
 	"github.com/keptn-contrib/prometheus-service/utils"
 )
+
+const remediationTaskName = "remediation"
 
 type alertManagerEvent struct {
 	Receiver string  `json:"receiver"`
@@ -48,6 +49,24 @@ type annotations struct {
 	Description string `json:"descriptions,omitempty"`
 }
 
+type EventData struct {
+	Project     string            `json:"project,omitempty"`
+	Stage       string            `json:"stage,omitempty"`
+	Service     string            `json:"service,omitempty"`
+	Labels      map[string]string `json:"labels"`
+	Problem     ProblemData       `json:"problem"`
+}
+
+type ProblemData struct {
+	State          string          `json:"State,omitempty"`
+	ProblemID      string          `json:"ProblemID"`
+	ProblemTitle   string          `json:"ProblemTitle"`
+	ProblemDetails json.RawMessage `json:"ProblemDetails"`
+	PID            string          `json:"PID"`
+	ProblemURL     string          `json:"ProblemURL,omitempty"`
+	ImpactedEntity string          `json:"ImpactedEntity,omitempty"`
+}
+
 // ProcessAndForwardAlertEvent reads the payload from the request and sends a valid Cloud event to the keptn event broker
 func ProcessAndForwardAlertEvent(rw http.ResponseWriter, requestBody []byte, logger *keptn.Logger, shkeptncontext string) {
 	var event alertManagerEvent
@@ -66,16 +85,20 @@ func ProcessAndForwardAlertEvent(rw http.ResponseWriter, requestBody []byte, log
 		return
 	}
 
-	newProblemData := keptnevents.ProblemEventData{
+	problemData := ProblemData{
 		State:          problemState,
 		ProblemID:      "",
 		ProblemTitle:   event.Alerts[0].Annotations.Summary,
 		ProblemDetails: json.RawMessage(`{"problemDetails":"` + event.Alerts[0].Annotations.Description + `"}`),
 		ProblemURL:     event.Alerts[0].GeneratorURL,
 		ImpactedEntity: event.Alerts[0].Labels.PodName,
+	}
+
+	newProblemData := EventData{
 		Project:        event.Alerts[0].Labels.Project,
 		Stage:          event.Alerts[0].Labels.Stage,
 		Service:        event.Alerts[0].Labels.Service,
+		Problem:        problemData,
 	}
 
 	if event.Alerts[0].Fingerprint != "" {
@@ -93,17 +116,18 @@ func ProcessAndForwardAlertEvent(rw http.ResponseWriter, requestBody []byte, log
 	}
 }
 
-func createAndSendCE(problemData keptnevents.ProblemEventData, shkeptncontext string) error {
+func createAndSendCE(problemData EventData, shkeptncontext string) error {
 	source, _ := url.Parse("prometheus")
 
 	eventBrokerURL, err := utils.GetEventBrokerURL()
 
+	eventType := keptnv2.GetTriggeredEventType(problemData.Stage + "." + remediationTaskName)
+
 	event := cloudevents.NewEvent()
 	event.SetID(uuid.New().String())
 	event.SetTime(time.Now())
-	event.SetType(keptnevents.ProblemOpenEventType)
+	event.SetType(eventType)
 	event.SetSource(source.String())
-	event.SetExtension("shkeptncontext", shkeptncontext)
 	event.SetDataContentType(cloudevents.ApplicationJSON)
 	event.SetData(cloudevents.ApplicationJSON, problemData)
 

--- a/eventhandling/configureEvent.go
+++ b/eventhandling/configureEvent.go
@@ -329,7 +329,7 @@ func (eh ConfigureMonitoringEventHandler) updatePrometheusConfigMap(eventData ke
 		return err
 	}
 	// apply
-	cmPrometheus.Data["prometheus.rules"] = string(alertingRulesYAMLString)
+	cmPrometheus.Data["alerting_rules.yml"] = string(alertingRulesYAMLString)
 	cmPrometheus.Data[env.PrometheusConfigFileName] = config.String()
 	_, err = api.CoreV1().ConfigMaps(env.PrometheusNamespace).Update(cmPrometheus)
 	if err != nil {

--- a/trigger_remediation.json
+++ b/trigger_remediation.json
@@ -1,0 +1,17 @@
+{
+  "type": "sh.keptn.event.production.remediation.triggered",
+  "specversion": "1.0",
+  "source": "https://github.com/keptn/keptn/prometheus-service",
+  "id": "f2b878d3-03c0-4e8f-bc3f-454bc1b3d79d",
+  "time": "2019-06-07T07:02:15.64489Z",
+  "contenttype": "application/json",
+  "data": {
+    "project": "sockshop",
+    "stage": "production",
+    "service": "carts",
+    "problem": {
+      "problemTitle": "response_time_p90",
+      "rootCause": "Response time degradation"
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes:
- the Alerting rules have been added to the wrong place in the ConfigMap
- send a `sh.keptn.event.remediation.triggered` event instead of a `problem.opened`
- the payload of the `remediation.triggered` must look as follows: 

```
{
  "type": "sh.keptn.event.production.remediation.triggered",
  "specversion": "1.0",
  "source": "https://github.com/keptn/keptn/prometheus-service",
  "id": "f2b878d3-03c0-4e8f-bc3f-454bc1b3d79d",
  "time": "2019-06-07T07:02:15.64489Z",
  "contenttype": "application/json",
  "data": {
    "project": "sockshop",
    "stage": "production",
    "service": "carts",
    "problem": {
      "problemTitle": "response_time_p90",
      "rootCause": "Response time degradation"
    }
  }
}
```