### PR TITLE
allow configuration-service env variable

### DIFF
--- a/eventhandling/configureEvent.go
+++ b/eventhandling/configureEvent.go
@@ -45,7 +45,7 @@ type envConfig struct {
 	AlertManagerTemplateConfigMap string `envconfig:"ALERT_MANAGER_TEMPLATE_CM" default:"alertmanager-templates"`
 	PrometheusConfigFileName      string `envconfig:"PROMETHEUS_CONFIG_FILENAME" default:"prometheus.yml"`
 	AlertManagerConfigFileName    string `envconfig:"ALERT_MANAGER_CONFIG_FILENAME" default:"alertmanager.yml"`
-	ConfigurationServiceUrl       string `envconfig:"CONFIGURATION_SERVICE" default:""`
+	ConfigurationServiceURL       string `envconfig:"CONFIGURATION_SERVICE" default:""`
 }
 
 // ConfigureMonitoringEventHandler is responsible for processing configure monitoring events
@@ -598,7 +598,7 @@ func getScrapeConfig(config *prometheusconfig.Config, name string) *prometheusco
 }
 
 func getConfigurationServiceURL() string {
-	return env.ConfigurationServiceUrl
+	return env.ConfigurationServiceURL
 }
 
 func retrieveSLOs(eventData keptnevents.ConfigureMonitoringEventData, stage string, logger keptn.LoggerInterface) (*keptnevents.ServiceLevelObjectives, error) {

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ type envConfig struct {
 	// Port on which to listen for cloudevents
 	Port                    int    `envconfig:"RCV_PORT" default:"8080"`
 	Path                    string `envconfig:"RCV_PATH" default:"/"`
-	ConfigurationServiceUrl string `envconfig:"CONFIGURATION_SERVICE" default:""`
+	ConfigurationServiceURL string `envconfig:"CONFIGURATION_SERVICE" default:""`
 }
 
 type prometheusCredentials struct {
@@ -69,7 +69,7 @@ func main() {
 	if err := envconfig.Process("", &env); err != nil {
 		logger.Error(fmt.Sprintf("Failed to process env var: %s", err))
 	}
-	logger.Debug(fmt.Sprintf("Configuration service: %s", env.ConfigurationServiceUrl))
+	logger.Debug(fmt.Sprintf("Configuration service: %s", env.ConfigurationServiceURL))
 	os.Exit(_main(env))
 }
 


### PR DESCRIPTION
Allow using the `CONFIGURATION_SERVICE` environment variable to be able to connect to a configuration service at the Keptn control plane