### PR TITLE
#198 Re-introduce scrape interval of 5s

### DIFF
--- a/eventhandling/configureEvent.go
+++ b/eventhandling/configureEvent.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/kelseyhightower/envconfig"
@@ -557,7 +558,12 @@ func createScrapeJobConfig(scrapeConfig *prometheusconfig.ScrapeConfig, config *
 		scrapeConfig = &prometheusconfig.ScrapeConfig{}
 		config.ScrapeConfigs = append(config.ScrapeConfigs, scrapeConfig)
 	}
+
+	// define scrape job name
 	scrapeConfig.JobName = scrapeConfigName
+	// set scrape interval to 5 seconds
+	scrapeConfig.ScrapeInterval = prometheus_model.Duration(5 * time.Second)
+	// configure metrics path (default: /metrics)
 	scrapeConfig.MetricsPath = utils.EnvVarOrDefault(metricsScrapePathEnvName, "/metrics")
 	scrapeConfig.ServiceDiscoveryConfig = prometheus_sd_config.ServiceDiscoveryConfig{
 		StaticConfigs: []*targetgroup.Group{


### PR DESCRIPTION
## This PR

- re-introduces the scrape-interval on the level of a scrape-job, rather than globally for prometheus

Fixes #198 and #179

## Proof

**Note**: I've tested it with 10s (see screenshots), but I've set it to 5s in source code afterwards

![image](https://user-images.githubusercontent.com/56065213/143438045-586c6b93-8ac6-46ea-b93b-eef49e412fe0.png)

![image](https://user-images.githubusercontent.com/56065213/143437893-6c835be5-0c97-4f12-9b41-1f72722c166a.png)

![image](https://user-images.githubusercontent.com/56065213/143437721-dab68911-53fa-4294-aae2-279a9891cb44.png)

