### PR TITLE
fix(core): fix event sending and added keptncontext (#60)

### DIFF
--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -194,10 +194,6 @@ spec:
               value: '/metrics'
             - name: CONFIGURATION_SERVICE
               value: 'http://configuration-service:8080'
-            - name: EVENTBROKER
-              value: 'http://localhost:8081/event'
-            - name: API
-              value: 'ws://api-service:8080/websocket'
             - name: PROMETHEUS_NS
               value: 'monitoring'
             - name: PROMETHEUS_CM

--- a/prometheus_alert.json
+++ b/prometheus_alert.json
@@ -1,0 +1,41 @@
+{
+  "receiver": "keptn_integration",
+  "status": "firing",
+  "alerts": [
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "response_time_p90",
+        "pod_name": "carts-primary",
+        "project": "sockshop",
+        "service": "carts",
+        "severity": "webhook",
+        "stage": "production"
+      },
+      "annotations": {
+        "descriptions": "Pod name ",
+        "summary": "response_time_p90"
+      },
+      "startsAt": "2021-11-26T10:57:14.057345112Z",
+      "endsAt": "0001-01-01T00:00:00Z",
+      "generatorURL": "http://prometheus-server-6776d8bb7d-pqkln:9090/graph?g0.expr=histogram_quantile%280.9%2C+sum+by%28le%29+%28rate%28http_response_time_milliseconds_bucket%7Bhandler%3D%22ItemsController.addToCart%22%2Cjob%3D%22carts-sockshop-production-primary%22%7D%5B3m%5D%29%29%29+%3E+1000\\u0026g0.tab=1",
+      "fingerprint": "8dd2c31a47cf2e78"
+    }
+  ],
+  "groupLabels": {},
+  "commonLabels": {
+    "alertname": "response_time_p90",
+    "pod_name": "carts-primary",
+    "project": "sockshop",
+    "service": "carts",
+    "severity": "webhook",
+    "stage": "production"
+  },
+  "commonAnnotations": {
+    "descriptions": "Pod name ",
+    "summary": "response_time_p90"
+  },
+  "externalURL": "http://localhost:9093",
+  "version": "4",
+  "truncatedAlerts": 0
+}


### PR DESCRIPTION
## This PR

- Re-adds shkeptncontext to the remediation.triggered CloudEvents, such that triggering the sequence works again.
- Removes legacy "EVENTBROKER" entries
- Adds prometheus_alert.json as an example alert (e.g., `curl -X POST -H "Content-Type: application/json" -d @prometheus_alert.json http://localhost:8080`)

Fixes #60

Related to #195


