### PR TITLE
fix(core): Fix event forwarding to localhost (#195)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,5 @@ README.md
 .idea
 skaffold.yaml
 reviewdog.yml
+charts/
+deploy/


### PR DESCRIPTION
## This PR

- Fixes the event forwarding when a cloudevent is received on port 8080 via the golang http handler
- Updates dockerignore to speed up docker build 

Fixes #195 

