### PR TITLE
build(release): prepare 0.7.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,21 +27,23 @@ Please always double-check the version of Keptn you are using compared to the ve
 
 
 | Keptn Version    | [Prometheus Service Image](https://hub.docker.com/r/keptncontrib/prometheus-service/tags) |
-|:----------------:|:----------------------------------------:|
-|       0.5.x      | keptncontrib/prometheus-service:0.2.0  |
-|       0.6.x      | keptncontrib/prometheus-service:0.3.0  |
-|       0.6.1      | keptncontrib/prometheus-service:0.3.2  |
-|       0.6.2      | keptncontrib/prometheus-service:0.3.4  |
-|   0.7.0, 0.7.1   | keptncontrib/prometheus-service:0.3.5  |
-|       0.7.2      | keptncontrib/prometheus-service:0.3.6  |
-|   0.8.0-alpha    | keptncontrib/prometheus-service:0.4.0-alpha  |
-|   0.8.0          | keptncontrib/prometheus-service:0.4.0  |
-|   0.8.1, 0.8.2   | keptncontrib/prometheus-service:0.5.0  |
-|   0.8.1 - 0.8.3  | keptncontrib/prometheus-service:0.6.0  |
-|   0.8.4 - 0.8.7  | keptncontrib/prometheus-service:0.6.1  |
-|       0.9.0      | keptncontrib/prometheus-service:0.6.2  |
-|   0.9.0 - 0.9.2  | keptncontrib/prometheus-service:0.7.0  |
-|   0.10.0         | keptncontrib/prometheus-service:0.7.1  |
+|:----------------:|:-----------------------------------------------------------------------------------------:|
+|       0.5.x      |                           keptncontrib/prometheus-service:0.2.0                           |
+|       0.6.x      |                           keptncontrib/prometheus-service:0.3.0                           |
+|       0.6.1      |                           keptncontrib/prometheus-service:0.3.2                           |
+|       0.6.2      |                           keptncontrib/prometheus-service:0.3.4                           |
+|   0.7.0, 0.7.1   |                           keptncontrib/prometheus-service:0.3.5                           |
+|       0.7.2      |                           keptncontrib/prometheus-service:0.3.6                           |
+|   0.8.0-alpha    |                        keptncontrib/prometheus-service:0.4.0-alpha                        |
+|   0.8.0          |                           keptncontrib/prometheus-service:0.4.0                           |
+|   0.8.1, 0.8.2   |                           keptncontrib/prometheus-service:0.5.0                           |
+|   0.8.1 - 0.8.3  |                           keptncontrib/prometheus-service:0.6.0                           |
+|   0.8.4 - 0.8.7  |                           keptncontrib/prometheus-service:0.6.1                           |
+|       0.9.0      |                           keptncontrib/prometheus-service:0.6.2                           |
+|   0.9.0 - 0.9.2  |                           keptncontrib/prometheus-service:0.7.0                           |
+|   0.10.0         |                           keptncontrib/prometheus-service:0.7.1                           |
+|   0.10.0         |                           keptncontrib/prometheus-service:0.7.2                           |
+
 
 ## Setup Prometheus Monitoring
 

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,0 +1,44 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: keptn-prometheus-service
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - configmaps
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - "apps"
+    resources:
+      - deployments
+    verbs:
+      - create
+      - update
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: keptn-prometheus-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: keptn-prometheus-service
+subjects:
+  - kind: ServiceAccount
+    name: keptn-prometheus-service
+    namespace: keptn

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -5,51 +5,6 @@ metadata:
   namespace: keptn
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: keptn-prometheus-service
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - services
-      - configmaps
-    verbs:
-      - get
-      - create
-      - update
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-      - create
-      - update
-      - delete
-  - apiGroups:
-      - "apps"
-    resources:
-      - deployments
-    verbs:
-      - create
-      - update
-      - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: keptn-prometheus-service
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: keptn-prometheus-service
-subjects:
-  - kind: ServiceAccount
-    name: keptn-prometheus-service
-    namespace: keptn
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: keptn-create-prom-clusterrole
@@ -175,11 +130,11 @@ spec:
       labels:
         run: prometheus-service
         app.kubernetes.io/name: prometheus-service
-        app.kubernetes.io/version: 0.7.1
+        app.kubernetes.io/version: 0.7.2
     spec:
       containers:
         - name: prometheus-service
-          image: keptncontrib/prometheus-service:0.7.1
+          image: keptncontrib/prometheus-service:0.7.2
           ports:
             - containerPort: 8080
           resources:


### PR DESCRIPTION
## This PR

- Prepares for the 0.7.2 release
- Re-introduces role.yaml (and removes it from service.yaml), as those are two separate manifests that need to be applied independently, e.g.:
```
kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/prometheus-service/release-0.7.1/deploy/service.yaml
kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/prometheus-service/release-0.7.1/deploy/role.yaml -n monitoring
```
FYI @solidnerd 
