### PR TITLE
chore: remove eventbroker from code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,17 +21,15 @@ COPY go.mod go.sum ./
 # Download dependencies
 RUN go mod download
 
-ARG debugBuild
-
-# set buildflags for debug build
-RUN if [ ! -z "$debugBuild" ]; then export BUILDFLAGS='-gcflags "all=-N -l"'; fi
-
 # Copy local code to the container image.
 COPY . .
 
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+
 # Build the command inside the container.
 # (You may fetch or manage dependencies here, either manually or with a tool like "godep".)
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o prometheus-service
+RUN GOOS=linux go build -ldflags '-linkmode=external' -gcflags="${SKAFFOLD_GO_GCFLAGS}" -v -o prometheus-service
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -221,7 +221,7 @@ spec:
         - name: distributor
           image: keptn/distributor:0.10.0
           ports:
-            - containerPort: 8081
+            - containerPort: 8080
           resources:
             requests:
               memory: "16Mi"

--- a/eventhandling/configureEvent.go
+++ b/eventhandling/configureEvent.go
@@ -657,6 +657,7 @@ func (eh ConfigureMonitoringEventHandler) sendConfigureMonitoringFinishedEvent(c
 func (eh ConfigureMonitoringEventHandler) handleError(e *keptnevents.ConfigureMonitoringEventData, msg string) error {
 	//logger.Error(msg)
 	if err := eh.sendConfigureMonitoringFinishedEvent(e, keptnv2.StatusErrored, keptnv2.ResultFailed, msg); err != nil {
+		// an additional error occurred when trying to send configure monitoring finished back to Keptn
 		eh.logger.Error(err.Error())
 	}
 	return errors.New(msg)

--- a/main.go
+++ b/main.go
@@ -31,7 +31,6 @@ import (
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-const eventbroker = "EVENTBROKER"
 const sliResourceURI = "prometheus/sli.yaml"
 const serviceName = "prometheus-service"
 
@@ -112,15 +111,7 @@ func gotEvent(event cloudevents.Event) error {
 
 	logger := keptncommon.NewLogger(shkeptncontext, event.Context.GetID(), "prometheus-service")
 
-	eventBrokerURL, err := utils.GetEventBrokerURL()
-	if err != nil {
-		logger.Error(err.Error())
-		return err
-	}
-
-	keptnHandler, err := keptnv2.NewKeptn(&event, keptncommon.KeptnOpts{
-		EventBrokerURL: eventBrokerURL,
-	})
+	keptnHandler, err := keptnv2.NewKeptn(&event, keptncommon.KeptnOpts{})
 
 	if err != nil {
 		return fmt.Errorf("could not create Keptn handler: %v", err)
@@ -227,12 +218,7 @@ func retrieveMetrics(event cloudevents.Event, eventData *keptnv2.GetSLITriggered
 		return nil, err
 	}
 
-	eventBrokerURL := os.Getenv(eventbroker)
-	if eventBrokerURL == "" {
-		eventBrokerURL = "http://event-broker/keptn"
-	}
-
-	keptnHandler, err := keptnv2.NewKeptn(&event, keptncommon.KeptnOpts{EventBrokerURL: eventBrokerURL})
+	keptnHandler, err := keptnv2.NewKeptn(&event, keptncommon.KeptnOpts{})
 	if err != nil {
 		return nil, err
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,38 +1,8 @@
 package utils
 
 import (
-	"fmt"
-	"net/url"
 	"os"
 )
-
-const eventbroker = "EVENTBROKER"
-
-// GetServiceEndpoint retrieves an endpoint stored in an environment variable and sets http as default scheme
-func GetServiceEndpoint(service string) (url.URL, error) {
-	url, err := url.Parse(os.Getenv(service))
-	if err != nil {
-		return *url, fmt.Errorf("Failed to retrieve value from ENVIRONMENT_VARIABLE: %s", service)
-	}
-
-	if url.Scheme == "" {
-		url.Scheme = "http"
-	}
-
-	return *url, nil
-}
-
-// GetEventBrokerURL godoc
-func GetEventBrokerURL() (string, error) {
-	var eventBrokerURL string
-	endpoint, err := GetServiceEndpoint(eventbroker)
-	if err != nil {
-		eventBrokerURL = "http://localhost:8081/event"
-		return "", fmt.Errorf("Could not parse EVENTBROKER URL %s: %s. Using default: %s", os.Getenv(eventbroker), err.Error(), eventBrokerURL)
-	}
-	eventBrokerURL = endpoint.String()
-	return eventBrokerURL, nil
-}
 
 // EnvVarOrDefault returns the value of the environment variable named "envName" if found or "defaultVal" otherwise
 func EnvVarOrDefault(envName, defaultVal string) string {
@@ -41,15 +11,4 @@ func EnvVarOrDefault(envName, defaultVal string) string {
 	} else {
 		return val
 	}
-}
-
-// EnvVar returns the value of the environment variable named "envName" if found or empty string otherwise
-func EnvVar(envName string) string {
-	return os.Getenv(envName)
-}
-
-// EnvVarEqualsTo compares the value of the environment variable named "envName" to "equalsTo"
-// and returns true if they are equal, false otherwise
-func EnvVarEqualsTo(envName, equalsTo string) bool {
-	return EnvVar(envName) == equalsTo
 }


### PR DESCRIPTION
## This PR

- removes eventbroker from our codebase as this is no longer available since a couple of keptn versions
- use `SKAFFOLD_GO_GCFLAGS` in Dockerfile for proper debugging flags when using skaffolds
- 
