### PR TITLE
chore: renovate should use semantic commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "config:base",
     ":gitSignOff",
+    ":semanticCommits",
     ":semanticCommitTypeAll(build)",
     ":semanticCommitScope(deps)",
     "group:monorepos"


### PR DESCRIPTION
Renovate wasn't using semantic commits so far.

According to https://docs.renovatebot.com/semantic-commits/ we just need to add `:semanticCommits` to the extends array