### PR TITLE
build: update gh workflows to re-use keptn/gh-automation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,79 +16,7 @@ defaults:
 jobs:
   prepare_ci_run:
     name: Prepare CI Run
-    # Prepare CI Run looks at what has been changed in this commit/PR/... and determines which artifacts should be
-    # built afterwards (in other jobs that depend on this one).
-    runs-on: ubuntu-20.04
-    outputs: # declare what this job outputs (so it can be re-used for other jobs)
-      # build config
-      # metadata
-      GIT_SHA: ${{ steps.extract_branch.outputs.GIT_SHA }}
-      BRANCH: ${{ steps.extract_branch.outputs.BRANCH }}
-      BRANCH_SLUG: ${{ steps.extract_branch.outputs.BRANCH_SLUG }}
-      VERSION: ${{ steps.get_version.outputs.VERSION }}
-      DATE: ${{ steps.get_datetime.outputs.DATE }}
-      TIME: ${{ steps.get_datetime.outputs.TIME }}
-      DATETIME: ${{ steps.get_datetime.outputs.DATETIME }}
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2.4.0
-        with:
-          fetch-depth: 0 # need to checkout "all commits" for certain features to work (e.g., get all changed files)
-
-      - name: Load CI Environment from .ci_env
-        id: load_ci_env
-        uses: c-py/action-dotenv-to-setenv@v3
-        with:
-          env-file: .ci_env
-
-      - name: Extract branch name
-        id: extract_branch
-        # see https://github.com/keptn/gh-action-extract-branch-name for details
-        uses: keptn/gh-action-extract-branch-name@main
-
-      - name: 'Get Previous tag'
-        id: get_previous_tag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1.1"
-      - name: 'Get next patch version'
-        id: get_next_semver_tag
-        uses: "WyriHaximus/github-action-next-semvers@v1.1"
-        with:
-          version: ${{ steps.get_previous_tag.outputs.tag }}
-      - name: Get the version
-        id: get_version
-        env:
-          BRANCH: ${{ steps.extract_branch.outputs.BRANCH }}
-          BRANCH_SLUG: ${{ steps.extract_branch.outputs.BRANCH_SLUG }}
-        shell: bash
-        run: |
-          # determine version
-          GIT_LAST_TAG=${{ steps.get_previous_tag.outputs.tag }}
-          GIT_NEXT_TAG=${{ steps.get_next_semver_tag.outputs.patch }}
-          echo "GIT_LAST_TAG=${GIT_LAST_TAG}, GIT_NEXT_TAG=${GIT_NEXT_TAG}"
-
-          if [[ "$BRANCH" == "release-"* ]]; then
-            # Release Branch: extract version from branch name
-            VERSION=${BRANCH#"release-"}
-            else
-            if [[ "$BRANCH" == "master" ]]; then
-              # master branch = latest
-              VERSION="${GIT_NEXT_TAG}-dev"
-            else
-              # Feature/Development Branch - use last tag with branch slug
-              VERSION="${GIT_NEXT_TAG}-dev-${BRANCH_SLUG}"
-            fi
-          fi
-
-          echo "VERSION=${VERSION}"
-
-          echo "##[set-output name=VERSION;]$(echo ${VERSION})"
-      - name: Get current date and time
-        id: get_datetime
-        run: |
-          echo "::set-output name=DATE::$(date +'%Y%m%d')"
-          echo "::set-output name=TIME::$(date +'%H%M')"
-          echo "::set-output name=DATETIME::$(date +'%Y%m%d')$(date +'%H%M')"
+    uses: keptn/gh-automation/.github/workflows/prepare-ci.yml@v1.4.0
 
   ############################################################################
   # Unit tests                                                               #
@@ -124,7 +52,7 @@ jobs:
 
       - name: Docker Build
         id: docker_build
-        uses: keptn/gh-automation/.github/actions/docker-build@v1.3.0
+        uses: keptn/gh-automation/.github/actions/docker-build@v1.4.0
         with:
           TAGS: |
             ${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE }}:${{ env.VERSION }}
@@ -137,7 +65,7 @@ jobs:
 
       - id: report_docker_build_to_pr
         name: Report Docker Build to PR
-        if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,7 +13,7 @@ jobs:
   pre-release:
     needs: test
     name: Pre-Release
-    uses: keptn/gh-automation/.github/workflows/pre-release-integration.yml@v1.3.0
+    uses: keptn/gh-automation/.github/workflows/pre-release-integration.yml@v1.4.0
 
   docker_build:
     needs: [pre-release]
@@ -32,7 +32,7 @@ jobs:
           env-file: .ci_env
 
       - name: Docker Build
-        uses: keptn/gh-automation/.github/actions/docker-build@v1.3.0
+        uses: keptn/gh-automation/.github/actions/docker-build@v1.4.0
         with:
           TAGS: |
             ${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE }}:${{ env.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     needs: test
     name: Release
-    uses: keptn/gh-automation/.github/workflows/release-integration.yml@v1.3.0
+    uses: keptn/gh-automation/.github/workflows/release-integration.yml@v1.4.0
 
   docker_build:
     needs: [release]
@@ -32,7 +32,7 @@ jobs:
           env-file: .ci_env
 
       - name: Docker Build
-        uses: keptn/gh-automation/.github/actions/docker-build@v1.3.0
+        uses: keptn/gh-automation/.github/actions/docker-build@v1.4.0
         with:
           TAGS: |
             ${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE }}:${{ env.VERSION }}

--- a/.github/workflows/validate-semantic-pr.yml
+++ b/.github/workflows/validate-semantic-pr.yml
@@ -7,7 +7,7 @@ on:
       - synchronize
 jobs:
   validate:
-    uses: keptn/gh-automation/.github/workflows/validate-semantic-pr.yml@v1.3.0
+    uses: keptn/gh-automation/.github/workflows/validate-semantic-pr.yml@v1.4.0
     with:
       # Configure which scopes are allowed.
       scopes: |


### PR DESCRIPTION
## This PR

- uses the brand new prepare-ci workflow from keptn/gh-automation to reduce lines of code
- updates the respective workflows/actions from keptn/gh-automation to use the latest release tag v1.4.0