### PR TITLE
feat: Use cloudevent for alerting endpoint

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -107,6 +107,8 @@ spec:
               value: 'sh.keptn.event.monitoring.configure,sh.keptn.event.configure-monitoring.triggered,sh.keptn.event.get-sli.triggered'
             - name: PUBSUB_RECIPIENT
               value: '127.0.0.1'
+            - name: PUBSUB_RECIPIENT_PATH
+              value: '/events'
             - name: STAGE_FILTER
               value: "{{ .Values.distributor.stageFilter }}"
             - name: PROJECT_FILTER

--- a/eventhandling/alertEvent.go
+++ b/eventhandling/alertEvent.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -52,7 +51,7 @@ type annotations struct {
 }
 
 // ProcessAndForwardAlertEvent reads the payload from the request and sends a valid Cloud event to the keptn event broker
-func ProcessAndForwardAlertEvent(rw http.ResponseWriter, requestBody []byte, logger *keptn.Logger, shkeptncontext string) {
+func ProcessAndForwardAlertEvent(requestBody []byte, logger *keptn.Logger, shkeptncontext string) {
 	var event alertManagerEvent
 
 	logger.Info("Received alert from Prometheus Alertmanager:" + string(requestBody))
@@ -94,10 +93,8 @@ func ProcessAndForwardAlertEvent(rw http.ResponseWriter, requestBody []byte, log
 	err = createAndSendCE(newEventData, shkeptncontext)
 	if err != nil {
 		logger.Error("Could not send cloud event: " + err.Error())
-		rw.WriteHeader(500)
 	} else {
 		logger.Debug("event successfully dispatched to eventbroker")
-		rw.WriteHeader(201)
 	}
 }
 

--- a/eventhandling/alertEvent.go
+++ b/eventhandling/alertEvent.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -51,7 +52,7 @@ type annotations struct {
 }
 
 // ProcessAndForwardAlertEvent reads the payload from the request and sends a valid Cloud event to the keptn event broker
-func ProcessAndForwardAlertEvent(requestBody []byte, logger *keptn.Logger, shkeptncontext string) {
+func ProcessAndForwardAlertEvent(rw http.ResponseWriter, requestBody []byte, logger *keptn.Logger, shkeptncontext string) {
 	var event alertManagerEvent
 
 	logger.Info("Received alert from Prometheus Alertmanager:" + string(requestBody))
@@ -93,8 +94,10 @@ func ProcessAndForwardAlertEvent(requestBody []byte, logger *keptn.Logger, shkep
 	err = createAndSendCE(newEventData, shkeptncontext)
 	if err != nil {
 		logger.Error("Could not send cloud event: " + err.Error())
+		rw.WriteHeader(500)
 	} else {
 		logger.Debug("event successfully dispatched to eventbroker")
+		rw.WriteHeader(201)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -1,40 +1,27 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"github.com/keptn-contrib/prometheus-service/eventhandling"
 	"github.com/keptn-contrib/prometheus-service/utils"
 	keptn "github.com/keptn/go-utils/pkg/lib"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/google/uuid"
 	"github.com/kelseyhightower/envconfig"
 	keptncommon "github.com/keptn/go-utils/pkg/lib/keptn"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 )
-
-type ceTest struct {
-	Specversion string `json:"specversion" yaml:"specversion"`
-}
 
 var (
 	env utils.EnvConfig
 )
 
 func main() {
-	/**
-	Note that prometheus-service requires to open multiple ports:
-	* 8080 (default port; exposed) - acts as the ingest for prometheus alerts, and also proxies CloudEvents to port 8082
-	* 8081 (Keptn distributor) - Port that keptn/distributor is listening too (default port for Keptn distributor)
-	* 8082 (CloudEvents; env.Port) - Port that the CloudEvents sdk is listening to; this port is not exposed, but will be used for internal communication
-	*/
 	logger := keptncommon.NewLogger("", "", utils.ServiceName)
 
 	env = utils.EnvConfig{}
@@ -46,12 +33,6 @@ func main() {
 	logger.Debug(fmt.Sprintf("Configuration service: %s", env.ConfigurationServiceURL))
 	logger.Debug(fmt.Sprintf("Port: %d, Path: %s", env.Port, env.Path))
 
-	// listen on port 8080 for any HTTP request (cloudevents are also handled, but forwarded to env.Port internally)
-	logger.Debug("Starting server on port 8080...")
-	http.HandleFunc("/", Handler)
-	http.HandleFunc("/health", HealthHandler)
-	go http.ListenAndServe(":8080", nil)
-
 	// start internal CloudEvents handler (on port env.Port)
 	os.Exit(_main(env))
 }
@@ -60,7 +41,7 @@ func _main(env utils.EnvConfig) int {
 	ctx := context.Background()
 	ctx = cloudevents.WithEncodingStructured(ctx)
 
-	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port))
+	p, err := cloudevents.NewHTTP(cloudevents.WithPath(env.Path), cloudevents.WithPort(env.Port), cloudevents.WithGetHandlerFunc(HTTPGetHandler))
 	if err != nil {
 		log.Fatalf("failed to create client, %v", err)
 	}
@@ -80,6 +61,14 @@ func gotEvent(event cloudevents.Event) error {
 	var shkeptncontext string
 	_ = event.Context.ExtensionAs("shkeptncontext", &shkeptncontext)
 
+	logger := keptncommon.NewLogger(shkeptncontext, "", utils.ServiceName)
+
+	// Send prometheus alert
+	if event.SpecVersion() == "" {
+		eventhandling.ProcessAndForwardAlertEvent(event.Data(), logger, shkeptncontext)
+		return nil
+	}
+
 	// convert v0.1.4 spec monitoring.configure CloudEvent into a v0.2.0 spec configure-monitoring.triggered CloudEvent
 	if event.Type() == keptn.ConfigureMonitoringEventType {
 		event.SetType(keptnv2.GetTriggeredEventType(keptnv2.ConfigureMonitoringTaskName))
@@ -91,13 +80,23 @@ func gotEvent(event cloudevents.Event) error {
 		return fmt.Errorf("could not create Keptn handler: %v", err)
 	}
 
-	logger := keptncommon.NewLogger(shkeptncontext, event.Context.GetID(), utils.ServiceName)
-
 	return eventhandling.NewEventHandler(event, logger, keptnHandler).HandleEvent()
 }
 
-// HealthHandler provides a basic health check
-func HealthHandler(w http.ResponseWriter, r *http.Request) {
+// HTTPGetHandler will handle all requests for '/health' and '/ready'
+func HTTPGetHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/health":
+		healthEndpointHandler(w, r)
+	case "/ready":
+		healthEndpointHandler(w, r)
+	default:
+		endpointNotFoundHandler(w, r)
+	}
+}
+
+// HealthHandler rerts a basic health check back
+func healthEndpointHandler(w http.ResponseWriter, r *http.Request) {
 	type StatusBody struct {
 		Status string `json:"status"`
 	}
@@ -114,51 +113,20 @@ func HealthHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Handler takes all http request and forwards it to the corresponding event handler (e.g., prometheus alert);
-// Note: cloudevents are also forwarded
-func Handler(rw http.ResponseWriter, req *http.Request) {
-	shkeptncontext := uuid.New().String()
-	logger := keptncommon.NewLogger(shkeptncontext, "", utils.ServiceName)
-	logger.Debug(fmt.Sprintf("%s %s", req.Method, req.URL))
-	logger.Debug("Receiving event which will be dispatched")
+// endpointNotFoundHandler will return 404 for requests
+func endpointNotFoundHandler(w http.ResponseWriter, r *http.Request) {
+	type StatusBody struct {
+		Status string `json:"status"`
+	}
 
-	body, err := ioutil.ReadAll(req.Body)
+	status := StatusBody{Status: "NOT FOUND"}
+
+	body, _ := json.Marshal(status)
+
+	w.Header().Set("content-type", "application/json")
+
+	_, err := w.Write(body)
 	if err != nil {
-		logger.Error(fmt.Sprintf("Failed to read body from requst: %s", err))
-		return
-	}
-
-	// try to deserialize the event to check if it contains specversion
-	event := ceTest{}
-	if err = json.Unmarshal(body, &event); err != nil {
-		logger.Debug("Failed to read body: " + err.Error() + "; content=" + string(body))
-		return
-	}
-
-	// check event whether event contains specversion to forward it to 8081; otherwise process it as prometheus alert
-	if event.Specversion == "" {
-		// this is a prometheus alert
-		eventhandling.ProcessAndForwardAlertEvent(rw, body, logger, shkeptncontext)
-	} else {
-		// this is a CloudEvent retrieved on port 8080 that needs to be forwarded to 8082 (env.Port)
-		forwardPath := fmt.Sprintf("http://localhost:%d%s", env.Port, env.Path)
-		logger.Debug("Forwarding cloudevent to " + forwardPath)
-		// forward cloudevent to cloudevents lister on env.Port (see main())
-		proxyReq, err := http.NewRequest(req.Method, forwardPath, bytes.NewReader(body))
-		proxyReq.Header.Set("Content-Type", "application/cloudevents+json")
-		resp, err := http.DefaultClient.Do(proxyReq)
-		if err != nil {
-			logger.Error("Could not send cloud event: " + err.Error())
-			return
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode < 200 || resp.StatusCode > 299 {
-			logger.Error(fmt.Sprintf("Could not process cloud event: Handler returned status %s", resp.Status))
-			rw.WriteHeader(500)
-		} else {
-			logger.Debug("event successfully sent to port 8081")
-			rw.WriteHeader(201)
-		}
+		log.Println(err)
 	}
 }

--- a/utils/env.go
+++ b/utils/env.go
@@ -9,7 +9,7 @@ const SliResourceURI = "prometheus/sli.yaml"
 // EnvConfig holds the configuration of environment variables that this service uses
 type EnvConfig struct {
 	// Port on which to listen for cloudevents
-	Port                          int    `envconfig:"RCV_PORT" default:"8082"` // Note: must not be 8080 and not 8081
+	Port                          int    `envconfig:"RCV_PORT" default:"8080"`
 	Path                          string `envconfig:"RCV_PATH" default:"/"`
 	ConfigurationServiceURL       string `envconfig:"CONFIGURATION_SERVICE" default:""`
 	PrometheusNamespace           string `envconfig:"PROMETHEUS_NS" default:""`

--- a/utils/env.go
+++ b/utils/env.go
@@ -10,7 +10,7 @@ const SliResourceURI = "prometheus/sli.yaml"
 type EnvConfig struct {
 	// Port on which to listen for cloudevents
 	Port                          int    `envconfig:"RCV_PORT" default:"8080"`
-	Path                          string `envconfig:"RCV_PATH" default:"/"`
+	Path                          string `envconfig:"RCV_PATH" default:"/events"`
 	ConfigurationServiceURL       string `envconfig:"CONFIGURATION_SERVICE" default:""`
 	PrometheusNamespace           string `envconfig:"PROMETHEUS_NS" default:""`
 	PrometheusConfigMap           string `envconfig:"PROMETHEUS_CM" default:""`


### PR DESCRIPTION
## This PR

- Use `cloudevents.WithGetHandlerFunc()` function to implement health checks and alerting endpoint  
- Remove other HTTP Endpoints
- Change `PORT` environment variable

## Fixes
#266 