### PR TITLE
chore: added a way to test prometheus alerts

### DIFF
--- a/prometheus_alert.http
+++ b/prometheus_alert.http
@@ -1,0 +1,16 @@
+# For a quick start check out our HTTP Requests collection (Tools|HTTP Client|Open HTTP Requests Collection) or
+# paste cURL into the file and request will be converted to HTTP Request format.
+#
+# Following HTTP Request Live Templates are available:
+# * 'gtrp' and 'gtr' create a GET request with or without query parameters;
+# * 'ptr' and 'ptrp' create a POST request with a simple or parameter-like body;
+# * 'mptr' and 'fptr' create a POST request to submit a form with a text or file field (multipart/form-data);
+
+# send service.create.finished test-event
+POST http://localhost:8080/
+Accept: application/json
+Cache-Control: no-cache
+Content-Type: application/json
+
+< ./prometheus_alert.json
+###


### PR DESCRIPTION
I added a helper utilty to test prometheus alerts.

This works nice in JetBrains IDEs, and in VS Code using [Huachao Mao REST Client in VS Code](https://marketplace.visualstudio.com/items?itemName=humao.rest-client).

![image](https://user-images.githubusercontent.com/56065213/154010274-e2fd5ba2-66f2-4ba4-a3ea-d686da9680ab.png)
