### PR TITLE
feat: Upgrade to Keptn 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Please always double-check the version of Keptn you are using compared to the ve
 |  0.9.0 - 0.9.2  |                           keptncontrib/prometheus-service:0.7.0                           |
 |     0.10.0      |                           keptncontrib/prometheus-service:0.7.1                           |
 |     0.10.0      |                           keptncontrib/prometheus-service:0.7.2                           |
-|     0.12.0      |                          keptncontrib/prometheus-service:0.7.3                            |
+|     0.12.0      |                           keptncontrib/prometheus-service:0.7.3                           |
+|     0.13.x      |                           keptncontrib/prometheus-service:0.7.4                           |
 
 \* This is the Keptn version we aim to be compatible with. Other versions should work too, but there is no guarantee.
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -23,7 +23,7 @@ distributor:
   image:
     repository: docker.io/keptn/distributor  # Container Image Name
     pullPolicy: IfNotPresent                 # Kubernetes Image Pull Policy
-    tag: "0.12.1"                            # Container Tag
+    tag: "0.13.4"                            # Container Tag
   config:
     queueGroup:
       enabled: true                          # Enable connection via Nats queue group to support exactly-once message processing

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.5.0
 	github.com/google/uuid v1.3.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.12.0
+	github.com/keptn/go-utils v0.13.0
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/prometheus/alertmanager v0.23.0
 	github.com/prometheus/common v0.32.0

--- a/go.sum
+++ b/go.sum
@@ -383,6 +383,8 @@ github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dv
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/keptn/go-utils v0.12.0 h1:iB/2qDJLt0V2OwkSAD4rH0lKEGlKyYNLzS/ZZ6HKZfY=
 github.com/keptn/go-utils v0.12.0/go.mod h1:yJM7pnCUj23VHKa2az9eWUTAmLDv94f6DVHON9qV1kU=
+github.com/keptn/go-utils v0.13.0 h1:jQ8EoWWa4EPamu4dis+AMzVD4YG2Yu/FEwvpgwslFrE=
+github.com/keptn/go-utils v0.13.0/go.mod h1:yJM7pnCUj23VHKa2az9eWUTAmLDv94f6DVHON9qV1kU=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -25,7 +25,7 @@ deploy:
         overrides:
           distributor:
             image:
-              tag: 0.12.1
+              tag: 0.13.4
           resources:
             limits:
               memory: 512Mi


### PR DESCRIPTION
## This PR

- Upgrades distributor to Keptn 0.13.4
- Upgrades go-utils to v0.13
- Updates compatibility matrix 