### PR TITLE
feat: Use Keptn secrets for storing external prometheus-server URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ To use an external Prometheus instance for a certain project, a secret containin
 
 ```console
 PROMETHEUS_USER=test
-PROMETHEUS_PASSWORD=test-password
+ PROMETHEUS_PASSWORD=test-password
 PROMETHEUS_URL=http://prometheus-server.monitoring.svc.cluster.local
 
 keptn create secret prometheus-credentials-<project> --scope="keptn-prometheus-service" --from-literal="PROMETHEUS_USER=$PROMETHEUS_USER" --from-literal="PROMETHEUS_PASSWORD=$PROMETHEUS_PASSWORD" --from-literal="PROMETHEUS_URL=$PROMETHEUS_URL"

--- a/README.md
+++ b/README.md
@@ -155,21 +155,15 @@ Per default, the service works with the following assumptions regarding the setu
 
 ### Using an external Prometheus instance
 
-To use a Prometheus instance other than the one that is being managed by Keptn for a certain project, a secret containing the URL and the access credentials has to be deployed into the `keptn` namespace. The secret must have the following format:
-
-```yaml
-user: test
-password: test
-url: http://prometheus-service.monitoring.svc.cluster.local:8080
-```
-
-If this information is stored in a file, e.g. `prometheus-creds.yaml`, it can be stored with the following command (don't forget to replace the `<project>` placeholder with the name of your project:
+To use an external Prometheus instance for a certain project, a secret containing the URL and the access credentials has to be created using the `keptn` cli (don't forget to replace the `<project>` placeholder with the name of your project):
 
 ```console
-kubectl create secret -n keptn generic prometheus-credentials-<project> --from-file=prometheus-credentials=./mock_secret.yaml
-```
+PROMETHEUS_USER=test
+PROMETHEUS_PASSWORD=test-password
+PROMETHEUS_URL=http://prometheus-server.monitoring.svc.cluster.local
 
-Please note that there is a naming convention for the secret, because this can be configured per **project**. Therefore, the secret has to have the name `prometheus-credentials-<project>`
+keptn create secret prometheus-credentials-<project> --scope="keptn-prometheus-service" --from-literal="PROMETHEUS_USER=$PROMETHEUS_USER" --from-literal="PROMETHEUS_PASSWORD=$PROMETHEUS_PASSWORD" --from-literal="PROMETHEUS_URL=$PROMETHEUS_URL"
+```
 
 ### Custom SLI queries
 
@@ -185,16 +179,21 @@ Users can override the predefined queries, as well as add custom queries by crea
       response_time_p95: histogram_quantile(0.95, sum by(le) (rate(http_response_time_milliseconds_bucket{handler="ItemsController.addToCart",job="$SERVICE-$PROJECT-$STAGE-canary"}[$DURATION_SECONDS])))
     ```
 
-* To store this configuration, you need to add this file to a Keptn's configuration store. This is done by using the Keptn CLI with the [keptn add-resource](https://keptn.sh/docs/0.14.x/reference/cli/commands/keptn_add-resource/) command (see [SLI Provider](https://keptn.sh/docs/0.14.x/quality_gates/sli-provider/) for more information).
+* To store this configuration, you need to add this file to a Keptn's configuration store, e.g., using the [keptn add-resource](https://keptn.sh/docs/0.14.x/reference/cli/commands/keptn_add-resource/) command:
+
+    ```console
+    keptn add-resource --project <project> --service <service> --stage <stage> --resource=sli.yaml --resourceUri=prometheus/sli.yaml
+    ```
 
 ---
 
 Within the user-defined queries, the following variables can be used to dynamically build the query, depending on the project/stage/service, and the time frame:
 
-- $PROJECT: will be replaced with the name of the project
-- $STAGE: will be replaced with the name of the stage
-- $SERVICE: will be replaced with the name of the service
-- $DURATION_SECONDS: will be replaced with the test run duration, e.g. 30s
+- `$PROJECT`: will be replaced with the name of the project
+- `$STAGE`: will be replaced with the name of the stage
+- `$SERVICE`: will be replaced with the name of the service
+- `$DEPLOYMENT`: type of the deployment (e.g., direct, canary, primary)
+- `$DURATION_SECONDS`: will be replaced with the test run duration, e.g. 30s
 
 For example, if an evaluation for the service **carts**  in the stage **production** of the project **sockshop** is triggered, and the tests ran for 30s these will be the resulting queries:
 

--- a/README.md
+++ b/README.md
@@ -165,9 +165,11 @@ PROMETHEUS_URL=http://prometheus-server.monitoring.svc.cluster.local
 keptn create secret prometheus-credentials-<project> --scope="keptn-prometheus-service" --from-literal="PROMETHEUS_USER=$PROMETHEUS_USER" --from-literal="PROMETHEUS_PASSWORD=$PROMETHEUS_PASSWORD" --from-literal="PROMETHEUS_URL=$PROMETHEUS_URL"
 ```
 
-### Custom SLI queries
+Note: This creates an actual Kubernetes secret, with some Kubernetes labels (`app.kubernetes.io/managed-by=keptn-secret-service`, `app.kubernetes.io/scope=prometheus-service`) and is bound to the correct role (`keptn-prometheus-svc-read`) which allow prometheus-service to access it.
 
-Users can override the predefined queries, as well as add custom queries by creating a SLI configuration.
+### User-defined Service Level Indicators (SLIs)
+
+Users can override the predefined queries, as well as add custom queries by creating a SLI configuration. 
 
 * A SLI configuration is a yaml file as shown below:
 
@@ -178,6 +180,7 @@ Users can override the predefined queries, as well as add custom queries by crea
       cpu_usage: avg(rate(container_cpu_usage_seconds_total{namespace="$PROJECT-$STAGE",pod_name=~"$SERVICE-primary-.*"}[5m]))
       response_time_p95: histogram_quantile(0.95, sum by(le) (rate(http_response_time_milliseconds_bucket{handler="ItemsController.addToCart",job="$SERVICE-$PROJECT-$STAGE-canary"}[$DURATION_SECONDS])))
     ```
+    This file contains a list of keys (e.g., `cpu_usage`) and a prometheus metric expressions (e.g., `avg(rate(...{filters}[timeframe]))`).
 
 * To store this configuration, you need to add this file to a Keptn's configuration store, e.g., using the [keptn add-resource](https://keptn.sh/docs/0.14.x/reference/cli/commands/keptn_add-resource/) command:
 

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -56,32 +56,6 @@ rules:
     verbs: [ "get" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: keptn-read-secret-prometheus
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - get
-      - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: keptn-prometheus-sli-service
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: keptn-read-secret-prometheus
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "prometheus-service.serviceAccountName" . }}
-    namespace: keptn
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: keptn-create-prom-clusterrole

--- a/utils/k8s.go
+++ b/utils/k8s.go
@@ -57,7 +57,7 @@ func ReadK8sSecretAsString(namespace string, secretName string, secretKey string
 
 	secret, err := api.CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("could not get secret %s: %w", secretName, err)
 	}
 
 	secretData, found := secret.Data[secretKey]

--- a/utils/k8s.go
+++ b/utils/k8s.go
@@ -46,3 +46,23 @@ func ListK8sServicesByLabel(svcLabelSelector, namespace string) (*v1.ServiceList
 	}
 	return svcList, nil
 }
+
+// ReadK8sSecretAsString returns the value of secretKey within a secret secretName within namespace namespace
+func ReadK8sSecretAsString(namespace string, secretName string, secretKey string) (string, error) {
+	api, err := GetKubeClient()
+
+	if err != nil {
+		return "", fmt.Errorf("could not initialize kubernetes client %w", err)
+	}
+
+	secret, err := api.CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	secretData, found := secret.Data[secretKey]
+	if !found {
+		return "", fmt.Errorf("key \"%s\" was not found in secret \"%s\"", secretKey, secretName)
+	}
+	return string(secretData), nil
+}


### PR DESCRIPTION
**Changes**

* Implement reading of secrets created via `keptn create secret`
* Update README accordingly
* Removed roles for accessing secrets - this is handled in Keptn secret-service by setting the scope of a secret (it was added in https://github.com/keptn/keptn/pull/6938 )

Fixes #274 

**How to test this:**
```console
PROMETHEUS_USER=test
 PROMETHEUS_PASSWORD=test-password
PROMETHEUS_URL=http://prometheus-server.monitoring.svc.cluster.local

keptn create secret prometheus-credentials-<project> --scope="keptn-prometheus-service" --from-literal="PROMETHEUS_USER=$PROMETHEUS_USER" --from-literal="PROMETHEUS_PASSWORD=$PROMETHEUS_PASSWORD" --from-literal="PROMETHEUS_URL=$PROMETHEUS_URL"
```

and trigger a delivery which will do an evaluation (e.g., in `staging`):
```console
keptn trigger delivery --project=sockshop --service=carts --image=docker.io/keptnexamples/carts --tag=0.13.1
```

I also added a fallback to support the previous kubectl based secrets.