### PR TITLE
build(deps): Upgrade setup-go action to use go.mod as a version file

### DIFF
--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -1,20 +1,15 @@
 name: 'Unit Tests'
 description: 'Run unit tests using go'
-inputs:
-  GO_VERSION:
-    description: The GO version that should be used for compilation / execution of the unit tests
-    required: false
-    default: "1.17"
 env:
   GO111MODULE: "on"
   GOPROXY: "https://proxy.golang.org"
 runs:
   using: "composite"
-  steps: 
-    - name: Install Go
-      uses: actions/setup-go@v3.0.0
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@v3.1.0
       with:
-        go-version: ${{ inputs.GO_VERSION }}
+        go-version-file: 'go.mod'
     - name: Install gotestsum
       shell: bash
       run: go install gotest.tools/gotestsum@latest

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -5,13 +5,13 @@ jobs:
     name: reviewdog
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.17
-        id: go
       - name: Check out code.
         uses: actions/checkout@v3.0.2
+      - name: Set up Go
+        uses: actions/setup-go@v3.1.0
+        with:
+          go-version-file: 'go.mod'
+        id: go
       - name: Install linters
         run: '( mkdir linters && cd linters && go get golang.org/x/lint/golint )'
       - uses: reviewdog/action-setup@v1.0.3


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

This PR upgrades setup-go action, and uses the brand new `go-version-file` feature, which lowers our future maintenance efforts for maining the go version in multiple files :)