### PR TITLE
feat: Upgrade to Keptn 0.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Please always double-check the version of Keptn you are using compared to the ve
 |     0.13.x      |                           keptncontrib/prometheus-service:0.7.5                           |
 |    0.14.2\**    |                           keptncontrib/prometheus-service:0.8.0                           |
  |     0.15.1      |                           keptncontrib/prometheus-service:0.8.1                           |
+|     0.16.0      |                           keptncontrib/prometheus-service:0.8.2                           |
 
 \* This is the Keptn version we aim to be compatible with. Other versions should work too, but there is no guarantee.
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -24,7 +24,7 @@ distributor:
   image:
     repository: docker.io/keptn/distributor  # Container Image Name
     pullPolicy: IfNotPresent                 # Kubernetes Image Pull Policy
-    tag: "0.15.1"                            # Container Tag
+    tag: "0.16.0"                            # Container Tag
   config:
     queueGroup:
       enabled: true                          # Enable connection via Nats queue group to support exactly-once message processing

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/keptn/go-utils v0.15.1
+	github.com/keptn/go-utils v0.16.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/prometheus/alertmanager v0.24.0
 	github.com/prometheus/client_golang v1.12.2

--- a/go.sum
+++ b/go.sum
@@ -325,6 +325,10 @@ github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dv
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/keptn/go-utils v0.15.1 h1:a7TVkpgZij2e921IM+yeohN+BLASRstEKwht9CwWnvQ=
 github.com/keptn/go-utils v0.15.1/go.mod h1:oxLLKz2u9KId2HgLH63+T0pUbcgiDd2GDkRrRKwxGUU=
+github.com/keptn/go-utils v0.16.0 h1:cMeiaI0gOJomuiSc5jtNFzz2YOhyM6+uFNWBcfd75Rc=
+github.com/keptn/go-utils v0.16.0/go.mod h1:oxLLKz2u9KId2HgLH63+T0pUbcgiDd2GDkRrRKwxGUU=
+github.com/keptn/go-utils v0.16.1 h1:P0BJuGeBfEN0I9Np0LMF7M3Kz/YVNt7I5q1maJeBPnc=
+github.com/keptn/go-utils v0.16.1/go.mod h1:oxLLKz2u9KId2HgLH63+T0pUbcgiDd2GDkRrRKwxGUU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -25,7 +25,7 @@ deploy:
         overrides:
           distributor:
             image:
-              tag: 0.15.1
+              tag: 0.16.0
           resources:
             limits:
               memory: 512Mi


### PR DESCRIPTION
## This PR

- Update distributor to version 0.16.0
- Update `go-utils` to v0.16.0
- Add version to compatibility matrix