### PR TITLE
feat: Autodetect prometheus and alertmanager namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Once this is done, you can go ahead and install prometheus-service:
 *Note*: Make sure to replace `<VERSION>` with the version you want to install.
 
 * Install Keptn prometheus-service in Kubernetes using the following command. This will install the prometheus-service into
-  the `keptn` namespace and will assume that prometheus and the alertmanager are installed in the `monitoring` namespace.
+  the `keptn` namespace and will autodetect the prometheus and the alertmanager namespaces.
 
     ```bash
     helm upgrade --install -n keptn prometheus-service \
@@ -86,7 +86,7 @@ Once this is done, you can go ahead and install prometheus-service:
     ```
 
 * (Optional) If you want to customize the namespaces of Keptn or the Prometheus installation, replace the environment
-  variable values according to the use case and apply the manifest:
+  variable values according to the use case and apply the manifest (this will automatically disable the autodetect):
 
     ```bash
     PROMETHEUS_NS=<PROMETHEUS_NS>

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -56,3 +56,62 @@ Create the name of the service account to use
 {{- define "prometheus-service.serviceAccountName" -}}
 keptn-prometheus-service
 {{- end }}
+
+
+{{/*
+Helper functions for auto detecting Prometheus namespace
+*/}}
+{{- define "prometheus-service.namespace" -}}
+    {{- /* Check if autodetect is set */ -}}
+    {{- if and (.Values.prometheus.autodetect) (eq .Values.prometheus.namespace "") }}
+        {{- $detectedPrometheusServer := list }}
+
+        {{- /* Find prometheus-server service */ -}}
+        {{- $services := lookup "v1" "Service" "" "" }}
+        {{- range $index, $srv := $services.items }}
+            {{- if (eq "prometheus-server" $srv.metadata.name ) }}
+                {{- $detectedPrometheusServer = append $detectedPrometheusServer $srv }}
+            {{- end }}
+        {{- end }}
+
+        {{- if eq (len $detectedPrometheusServer) 0 }}
+            {{- fail (printf "Unable to detect Prometheus in the kubernetes cluster! %+v" $services) }}
+        {{- end }}
+        {{- if gt (len $detectedPrometheusServer) 1 }}
+            {{- fail (printf "Detected more than one Prometheus installation: %+v" $detectedPrometheusServer) }}
+        {{- end }}
+
+        {{- (index $detectedPrometheusServer 0).metadata.namespace }}
+    {{- else }}
+        {{- .Values.prometheus.namespace }}
+    {{- end }}
+{{- end }}
+
+{{/*
+Helper functions for auto detecting Prometheus alertmanager namespace
+*/}}
+{{- define "prometheus-am-service.namespace" -}}
+    {{- /* Check if autodetect is set */ -}}
+    {{- if and (.Values.prometheus.autodetect_am) (eq .Values.prometheus.namespace_am "") }}
+        {{- $detectedPrometheusServer := list }}
+
+        {{- /* Find prometheus-alertmanager service */ -}}
+        {{- $services := lookup "v1" "Service" "" "" }}
+        {{- range $index, $srv := $services.items }}
+            {{- if (eq "prometheus-alertmanager" $srv.metadata.name ) }}
+                {{- $detectedPrometheusServer = append $detectedPrometheusServer $srv }}
+            {{- end }}
+        {{- end }}
+
+        {{- if eq (len $detectedPrometheusServer) 0 }}
+            {{- fail (printf "Unable to detect Prometheus in the kubernetes cluster! %+v" $services) }}
+        {{- end }}
+        {{- if gt (len $detectedPrometheusServer) 1 }}
+            {{- fail (printf "Detected more than one Prometheus installation: %+v" $detectedPrometheusServer) }}
+        {{- end }}
+
+        {{- (index $detectedPrometheusServer 0).metadata.namespace }}
+    {{- else }}
+        {{- .Values.prometheus.namespace_am }}
+    {{- end }}
+{{- end }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -75,13 +75,12 @@ Helper functions for auto detecting Prometheus namespace
         {{- end }}
 
         {{- if eq (len $detectedPrometheusServer) 0 }}
-            {{- fail (printf "Unable to detect Prometheus in the kubernetes cluster! %+v" $services) }}
-        {{- end }}
-        {{- if gt (len $detectedPrometheusServer) 1 }}
+            {{- fail (printf "Unable to detect Prometheus in the kubernetes cluster!") }}
+        {{- else if gt (len $detectedPrometheusServer) 1 }}
             {{- fail (printf "Detected more than one Prometheus installation: %+v" $detectedPrometheusServer) }}
+        {{ else }}
+            {{- (index $detectedPrometheusServer 0).metadata.namespace }}
         {{- end }}
-
-        {{- (index $detectedPrometheusServer 0).metadata.namespace }}
     {{- else }}
         {{- .Values.prometheus.namespace }}
     {{- end }}
@@ -104,13 +103,12 @@ Helper functions for auto detecting Prometheus alertmanager namespace
         {{- end }}
 
         {{- if eq (len $detectedPrometheusServer) 0 }}
-            {{- fail (printf "Unable to detect Prometheus in the kubernetes cluster! %+v" $services) }}
+            {{- fail (printf "Unable to detect Prometheus Alertmanager in the kubernetes cluster!") }}
+        {{- else if gt (len $detectedPrometheusServer) 1 }}
+            {{- fail (printf "Detected more than one Prometheus Alertmanager installation: %+v" $detectedPrometheusServer) }}
+        {{- else }}
+            {{- (index $detectedPrometheusServer 0).metadata.namespace }}
         {{- end }}
-        {{- if gt (len $detectedPrometheusServer) 1 }}
-            {{- fail (printf "Detected more than one Prometheus installation: %+v" $detectedPrometheusServer) }}
-        {{- end }}
-
-        {{- (index $detectedPrometheusServer 0).metadata.namespace }}
     {{- else }}
         {{- .Values.prometheus.namespace_am }}
     {{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
             - name: CONFIGURATION_SERVICE
               value: 'http://configuration-service:8080'
             - name: PROMETHEUS_NS
-              value: '{{ .Values.prometheus.namespace }}'
+              value: '{{- include "prometheus-service.namespace" . }}'
             - name: PROMETHEUS_CM
               value: 'prometheus-server'
             - name: PROMETHEUS_LABELS
@@ -69,7 +69,7 @@ spec:
             - name: ALERT_MANAGER_LABELS
               value: 'component=alertmanager'
             - name: ALERT_MANAGER_NS
-              value: '{{ .Values.prometheus.namespace_am }}'
+              value: '{{- include "prometheus-am-service.namespace" . }}'
             - name: ALERT_MANAGER_TEMPLATE_CM
               value: 'alertmanager-templates'
             - name: POD_NAMESPACE

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3,22 +3,62 @@
   "properties": {
     "prometheus": {
       "type": "object",
-      "if": {
-        "properties": {
-          "createTargets": {
-            "type": "boolean",
-            "const": false
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "createTargets": {
+                "type": "boolean",
+                "const": false
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "createAlerts": {
+                "type": "boolean",
+                "const": false
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "autodetect": {
+                "type": "boolean",
+                "const": false
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "namespace": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "autodetect_am": {
+                "type": "boolean",
+                "const": false
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "namespace_am": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
           }
         }
-      },
-      "then": {
-        "properties": {
-          "createAlerts": {
-            "type": "boolean",
-            "const": false
-          }
-        }
-      }
+      ]
     }
   }
 }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -12,12 +12,14 @@ image:
 
 # Prometheus specific configuration
 prometheus:
-  namespace: "monitoring"                    # K8s namespace where prometheus is installed
-  namespace_am: "monitoring"                 # K8s namespace where prometheus-alertmanager is installed
+  namespace: ""                              # K8s namespace where prometheus is installed
+  namespace_am: ""                           # K8s namespace where prometheus-alertmanager is installed
   endpoint: "http://prometheus-server.monitoring.svc.cluster.local:80"   # HTTP Endpoint for Prometheus
   scrapeInterval: 5s                         # Prometheus scrape interval. Value is a time duration expressed as a sequence of decimal numbers followed by unit suffixes such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
   createTargets: true                        # Enables the automatic creation of Prometheus targets (disable if you want to create targets manually)
   createAlerts: true                         # Enables the automatic creation of Prometheus alerts (cannot be true if createTargets is false)
+  autodetect: true                           # Enable of the auto-detection of the Prometheus installation
+  autodetect_am: true                        # Enable of the auto-detection of the Prometheus Alertmanager installation
 
 distributor:
   stageFilter: ""                            # Sets the stage this helm service belongs to


### PR DESCRIPTION
## This PR

- Autodetects the prometheus and alertmanager namespaces
- `namespace` and `namespace_am` values are used to overwrite the autodetect