### PR TITLE
fix: Alertmanager cloudevent payload

### DIFF
--- a/eventhandling/alertEvent.go
+++ b/eventhandling/alertEvent.go
@@ -89,7 +89,7 @@ func ProcessAndForwardAlertEvent(rw http.ResponseWriter, requestBody []byte, log
 		Service:        event.Alerts[0].Labels.Service,
 	}
 
-	newEventData := &remediationTriggeredEventData{
+	newEventData := remediationTriggeredEventData{
 		EventData: keptnv2.EventData{
 			Project: event.Alerts[0].Labels.Project,
 			Stage:   event.Alerts[0].Labels.Stage,
@@ -107,7 +107,7 @@ func ProcessAndForwardAlertEvent(rw http.ResponseWriter, requestBody []byte, log
 	}
 
 	logger.Debug("Sending event to eventbroker")
-	err = createAndSendCE(*newEventData, shkeptncontext)
+	err = createAndSendCE(newEventData, shkeptncontext)
 	if err != nil {
 		logger.Error("Could not send cloud event: " + err.Error())
 		rw.WriteHeader(500)

--- a/eventhandling/alertEvent.go
+++ b/eventhandling/alertEvent.go
@@ -51,7 +51,7 @@ type annotations struct {
 	Description string `json:"descriptions,omitempty"`
 }
 
-type RemediationTriggeredEventData struct {
+type remediationTriggeredEventData struct {
 	keptnv2.EventData
 
 	// Problem contains details about the problem
@@ -89,7 +89,7 @@ func ProcessAndForwardAlertEvent(rw http.ResponseWriter, requestBody []byte, log
 		Service:        event.Alerts[0].Labels.Service,
 	}
 
-	newEventData := &RemediationTriggeredEventData{
+	newEventData := &remediationTriggeredEventData{
 		EventData: keptnv2.EventData{
 			Project: event.Alerts[0].Labels.Project,
 			Stage:   event.Alerts[0].Labels.Stage,
@@ -118,7 +118,7 @@ func ProcessAndForwardAlertEvent(rw http.ResponseWriter, requestBody []byte, log
 }
 
 // createAndSendCE create a new problem.triggered event and send it to Keptn
-func createAndSendCE(problemData RemediationTriggeredEventData, shkeptncontext string) error {
+func createAndSendCE(problemData remediationTriggeredEventData, shkeptncontext string) error {
 	source, _ := url.Parse("prometheus")
 
 	eventType := keptnv2.GetTriggeredEventType(problemData.Stage + "." + remediationTaskName)

--- a/eventhandling/alertEvent.go
+++ b/eventhandling/alertEvent.go
@@ -69,11 +69,6 @@ func ProcessAndForwardAlertEvent(rw http.ResponseWriter, requestBody []byte, log
 		return
 	}
 
-	if event.Status == "resolved" {
-		logger.Info("Don't forward resolved problem.")
-		return
-	}
-
 	problemState := ""
 	if event.Status == "firing" {
 		problemState = "OPEN"


### PR DESCRIPTION
## This PR

- Fix bug where the remediation-service is unable to find action for problem type default
- Changes `remediation.triggered` cloud event payload to match the [remediation service](https://github.com/keptn/keptn/blob/master/remediation-service/handler/get_action_event_handler.go#L27)