### PR TITLE
fix: Default deployment in alerts/remediations to "primary" if not specified

### DIFF
--- a/eventhandling/alertEvent.go
+++ b/eventhandling/alertEvent.go
@@ -37,13 +37,14 @@ type alert struct {
 }
 
 type labels struct {
-	AlertName string `json:"alertname,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
-	PodName   string `json:"pod_name,omitempty"`
-	Severity  string `json:"severity,omitempty"`
-	Service   string `json:"service,omitempty" yaml:"service"`
-	Stage     string `json:"stage,omitempty" yaml:"stage"`
-	Project   string `json:"project,omitempty" yaml:"project"`
+	AlertName  string `json:"alertname,omitempty"`
+	Namespace  string `json:"namespace,omitempty"`
+	PodName    string `json:"pod_name,omitempty"`
+	Severity   string `json:"severity,omitempty"`
+	Service    string `json:"service,omitempty" yaml:"service"`
+	Stage      string `json:"stage,omitempty" yaml:"stage"`
+	Project    string `json:"project,omitempty" yaml:"project"`
+	Deployment string `json:"deployment,omitempty" yaml:"deployment"`
 }
 
 type annotations struct {
@@ -56,6 +57,8 @@ type remediationTriggeredEventData struct {
 
 	// Problem contains details about the problem
 	Problem keptncommons.ProblemEventData `json:"problem"`
+	// Deployment contains the current deployment, that is inferred from the alert event
+	Deployment string `json:"deployment"`
 }
 
 // ProcessAndForwardAlertEvent reads the payload from the request and sends a valid Cloud event to the keptn event broker
@@ -87,6 +90,9 @@ func ProcessAndForwardAlertEvent(rw http.ResponseWriter, requestBody []byte, log
 		Project:        event.Alerts[0].Labels.Project,
 		Stage:          event.Alerts[0].Labels.Stage,
 		Service:        event.Alerts[0].Labels.Service,
+		Labels: map[string]string{
+			"deployment": event.Alerts[0].Labels.Deployment,
+		},
 	}
 
 	newEventData := remediationTriggeredEventData{
@@ -94,8 +100,12 @@ func ProcessAndForwardAlertEvent(rw http.ResponseWriter, requestBody []byte, log
 			Project: event.Alerts[0].Labels.Project,
 			Stage:   event.Alerts[0].Labels.Stage,
 			Service: event.Alerts[0].Labels.Service,
+			Labels: map[string]string{
+				"Problem URL": event.Alerts[0].GeneratorURL,
+			},
 		},
-		Problem: problemData,
+		Problem:    problemData,
+		Deployment: event.Alerts[0].Labels.Deployment,
 	}
 
 	if event.Alerts[0].Fingerprint != "" {

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,7 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8V
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
@@ -111,6 +112,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
@@ -390,6 +392,7 @@ github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=

--- a/test/data/podtatohead.jes-config.yaml
+++ b/test/data/podtatohead.jes-config.yaml
@@ -42,3 +42,15 @@ actions:
                 "--host", "http://podtatoserver.$(KEPTN_PROJECT)-$(KEPTN_STAGE):80",
                 "--only-summary"
         ]
+
+  - name: "Rollback Action"
+    events:
+      - name: "sh.keptn.event.action.triggered"
+        jsonpath:
+          property: "$.data.action.action"
+          match: "rollback"
+    tasks:
+      - name: "Run roolback"
+        image: "alpine"
+        cmd: [ "sh" ]
+        args: [ "-c", "echo run rollback" ]

--- a/test/data/podtatohead.remediation.yaml
+++ b/test/data/podtatohead.remediation.yaml
@@ -4,7 +4,7 @@ metadata:
   name: remediation-configuration
 spec:
   remediations:
-    - problemType: "default"
+    - problemType: "response_time_p90"
       actionsOnOpen:
         - name: Rollback
           action: rollback

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -242,11 +242,11 @@ func (env testEnvironment) ShouldRun(semverConstraint string) error {
 // requireWaitForEvent checks if an event occurred in a specific time frame while polling the event bus of keptn, the eventValidator
 // should return true if the desired event was found
 func requireWaitForEvent(
-	t *testing.T, keptnApi *KeptnAPI, waitFor time.Duration, tick time.Duration, keptnContext *models.EventContext,
+	t *testing.T, keptnAPI *KeptnAPI, waitFor time.Duration, tick time.Duration, keptnContext *models.EventContext,
 	eventType string, eventValidator func(c *models.KeptnContextExtendedCE) bool, source string,
 ) {
 	requireWaitForFilteredEvent(t,
-		keptnApi,
+		keptnAPI,
 		waitFor,
 		tick,
 		&api.EventFilter{
@@ -287,6 +287,8 @@ func requireWaitForFilteredEvent(
 	require.Eventuallyf(t, checkForEventsToMatch, waitFor, tick, "did not receive keptn event: %s", eventFilter.EventType)
 }
 
+// BuildK8sConfig builds the kubernetes configuration from default or the configuration file that is specified
+// in the KUBECONFIG environment variable.
 func BuildK8sConfig() (*rest.Config, error) {
 	// Get full path of the kubeconfig file:
 	var kubeconfig string

--- a/test/events/prometheus-firing.json
+++ b/test/events/prometheus-firing.json
@@ -1,0 +1,44 @@
+{
+  "receiver": "keptn_integration",
+  "status": "firing",
+  "alerts": [
+    {
+      "status": "firing",
+      "labels": {
+        "alertname": "response_time_p90",
+        "deployment": "user_managed",
+        "pod_name": "podtatoserver-6b798d54bf-8qshg",
+        "project": "e2e-project",
+        "service": "podtatoserver",
+        "severity": "webhook",
+        "stage": "staging"
+      },
+      "annotations": {
+        "descriptions": "Pod name ",
+        "summary": "response_time_p90"
+      },
+      "startsAt": "2022-08-10T11:34:14.057Z",
+      "endsAt": "2022-08-10T11:40:14.057Z",
+      "generatorURL": "http://prometheus-server-558fc5f6fc-6qmjm:9090/graph?g0.expr=histogram_quantile%280.9%2C+sum+by%28le%29+%28rate%28http_response_time_milliseconds_bucket%7Bhandler%3D%22ItemsController.addToCart%22%2Cjob%3D%22carts-sockshop-production-primary%22%7D%5B3m%5D%29%29%29+%3E+500\\u0026g0.tab=1",
+      "fingerprint": "d26035f958c7e705"
+    }
+  ],
+  "groupLabels": {},
+  "commonLabels": {
+    "alertname": "response_time_p90",
+    "deployment": "user_managed",
+    "pod_name": "podtatoserver-6b798d54bf-8qshg",
+    "project": "e2e-project",
+    "service": "podtatoserver",
+    "severity": "webhook",
+    "stage": "staging"
+  },
+  "commonAnnotations": {
+    "descriptions": "Pod name ",
+    "summary": "response_time_p90"
+  },
+  "externalURL": "http://localhost:9093",
+  "version": "4",
+  "groupKey": "{}/{severity=\"webhook\"}:{}",
+  "truncatedAlerts": 0
+}

--- a/test/shipyard/podtatohead.deployment.yaml
+++ b/test/shipyard/podtatohead.deployment.yaml
@@ -17,3 +17,8 @@ spec:
             - name: "evaluation"
               properties:
                 timeframe: "1m"
+
+        - name: "remediation"
+          tasks:
+            - name: "get-action"
+            - name: "action"


### PR DESCRIPTION
## This PR
- ensures that the deployment type "primary" is used if not specified in the cloud event
- the deployment type is saved in the configure step into the alert manager 
- deployment type can be specified by labels

## Fixes
- #354 