### PR TITLE
feat!: Keptn 0.18 compatibility

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        keptn-version: ["0.14.2", "0.15.1", "0.16.0", "0.17.0"] # https://github.com/keptn/keptn/releases
+        keptn-version: ["0.18.1"] # https://github.com/keptn/keptn/releases
         prometheus-version: ["15.10.1"]
     env:
       GO_VERSION: 1.17
@@ -25,9 +25,10 @@ jobs:
       GO111MODULE: "on"
       BRANCH: ${{ github.head_ref || github.ref_name }}
       ENABLE_E2E_TEST: true
-      JES_VERSION: "0.2.3"
+      JES_VERSION: "0.2.4"
       JES_NAMESPACE: keptn-jes
       PROMETHEUS_NAMESPACE: monitoring
+      GITEA_PROVISIONER_VERSION: "0.1.1"
       GITEA_ADMIN_USERNAME: GiteaAdmin
       GITEA_NAMESPACE: gitea
       KUBECONFIG: /etc/rancher/k3s/k3s.yaml
@@ -61,6 +62,7 @@ jobs:
       - name: Install and start K3s
         run: |
           curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.21.12+k3s1" INSTALL_K3S_EXEC="--no-deploy traefik" K3S_KUBECONFIG_MODE="644" sh -
+
 
       - name: Wait for K3s to become ready
         timeout-minutes: 1
@@ -110,7 +112,8 @@ jobs:
           GITEA_ADMIN_PASSWORD: ${{ steps.gitea_credentials.outputs.GITEA_ADMIN_PASSWORD }}
           GITEA_ENDPOINT: ${{ steps.gitea.outputs.GITEA_ENDPOINT }}
         run: |
-          helm install keptn-gitea-provisioner-service https://github.com/keptn-sandbox/keptn-gitea-provisioner-service/releases/download/0.1.0/keptn-gitea-provisioner-service-0.1.0.tgz \
+          helm install keptn-gitea-provisioner-service \
+            https://github.com/keptn-sandbox/keptn-gitea-provisioner-service/releases/download/${GITEA_PROVISIONER_VERSION}/keptn-gitea-provisioner-service-${GITEA_PROVISIONER_VERSION}.tgz \
             --set gitea.endpoint=${GITEA_ENDPOINT} \
             --set gitea.admin.create=true \
             --set gitea.admin.username=${GITEA_ADMIN_USERNAME} \

--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ compatibility matrix below.
 
 | Keptn Version\* | [Prometheus Service Image](https://github.com/keptn-contrib/prometheus-service/pkgs/container/prometheus-service) |
 |:---------------:|:-----------------------------------------------------------------------------------------------------------------:|
-|     0.10.0      |                                       keptncontrib/prometheus-service:0.7.1                                       |
-|     0.10.0      |                                       keptncontrib/prometheus-service:0.7.2                                       |
-|     0.12.0      |                                       keptncontrib/prometheus-service:0.7.3                                       |
 |     0.13.x      |                                       keptncontrib/prometheus-service:0.7.4                                       |
 |     0.13.x      |                                       keptncontrib/prometheus-service:0.7.5                                       |
 |    0.14.2\**    |                                       keptncontrib/prometheus-service:0.8.0                                       |
@@ -27,6 +24,8 @@ compatibility matrix below.
 |     0.16.0      |                                     keptncontrib/prometheus-service:0.8.2\***                                     |
 |     0.16.0      |                                       keptncontrib/prometheus-service:0.8.3                                       |
 |     0.17.0      |                                       keptncontrib/prometheus-service:0.8.5                                       |
+|   0.18.0\****   |                                       keptncontrib/prometheus-service:0.9.0                                       |
+
 
 \* This is the Keptn version we aim to be compatible with. Other versions should work too, but there is no guarantee.
 
@@ -34,6 +33,9 @@ compatibility matrix below.
 change in NATS cluster name.
 
 \*** These versions are not compatible with Prometheus Alertmanager <= 0.24
+
+\**** This version is only compatible with Keptn 0.18.0 and potentially newer releases due to a breaking change with
+resource-service / configuration-service.
 
 You can find more information and older releases on
 the [Releases](https://github.com/keptn-contrib/prometheus-service/releases) page.


### PR DESCRIPTION
Unfortunately with the introduction of go-utils v0.18.0 (https://github.com/keptn-contrib/prometheus-service/pull/361) we lost compatiblity with Keptn 0.17 and older versions.
This is a breaking change in Keptn, and we need to go forward with it.

Therefore, this PR

* adds Keptn 0.18 to integration tests
* removes older version of Keptn from integration tests
* Added next release of prometheus-service to compatibility matrix
* Added a variable for the GITEA_PROVISIONER_VERSION and set it to the latest release 0.1.1

Fixes #362 

integration test run with 0.18.1 is green: https://github.com/keptn-contrib/prometheus-service/actions/runs/2946696911

