### PR TITLE
fix: Use configuration-service for now

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: METRICS_SCRAPE_PATH
               value: '/metrics'
             - name: CONFIGURATION_SERVICE
-              value: 'http://resource-service:8080'
+              value: 'http://configuration-service:8080'
             - name: PROMETHEUS_NS
               value: '{{- include "prometheus-service.namespace" . }}'
             - name: PROMETHEUS_CM


### PR DESCRIPTION
Apparently using "http://resource-service:8080" breaks backwards compatibility for now.
Introduced in: https://github.com/keptn-contrib/prometheus-service/pull/361

This PR changes it back to configuration-service:8080.

Fixes #362 :crossed_fingers: 
Integration Test Run: https://github.com/keptn-contrib/prometheus-service/actions/runs/2946474984