### PR TITLE
fix: Deployment Type in remediation.triggered incompatible with Keptn cloud events

### DIFF
--- a/eventhandling/alertEvent.go
+++ b/eventhandling/alertEvent.go
@@ -63,7 +63,8 @@ type remediationTriggeredEventData struct {
 	// Problem contains details about the problem
 	Problem keptncommons.ProblemEventData `json:"problem"`
 	// Deployment contains the current deployment, that is inferred from the alert event
-	Deployment string `json:"deployment"`
+
+	Deployment keptnv2.DeploymentFinishedData `json:"deployment"`
 }
 
 // ProcessAndForwardAlertEvent reads the payload from the request and sends a valid Cloud event to the keptn event broker
@@ -109,8 +110,12 @@ func ProcessAndForwardAlertEvent(rw http.ResponseWriter, requestBody []byte, log
 				"Problem URL": event.Alerts[0].GeneratorURL,
 			},
 		},
-		Problem:    problemData,
-		Deployment: event.Alerts[0].Labels.Deployment,
+		Problem: problemData,
+		Deployment: keptnv2.DeploymentFinishedData{
+			DeploymentNames: []string{
+				event.Alerts[0].Labels.Deployment,
+			},
+		},
 	}
 
 	if event.Alerts[0].Fingerprint != "" {

--- a/eventhandling/get_sli_event_handler.go
+++ b/eventhandling/get_sli_event_handler.go
@@ -60,7 +60,9 @@ func (eh GetSliEventHandler) Execute(k sdk.IKeptn, event sdk.KeptnEvent) (interf
 		return nil, &sdk.Error{Err: err, StatusType: keptnv2.StatusErrored, ResultType: keptnv2.ResultFailed, Message: "failed to get Prometheus API URL: " + err.Error()}
 	}
 
+	// determine deployment type based on what lighthouse-service is providing
 	deployment := eventData.Deployment // "canary", "primary" or "" (or "direct" or "user_managed")
+	// fallback: get deployment type from labels
 	if deploymentLabel, ok := eventData.Labels["deployment"]; deployment == "" && !ok {
 		log.Println("Warning: no deployment type specified in event, defaulting to \"primary\"")
 		deployment = "primary"

--- a/prometheus_alert.json
+++ b/prometheus_alert.json
@@ -10,16 +10,17 @@
         "project": "sockshop",
         "service": "carts",
         "severity": "webhook",
-        "stage": "production"
+        "stage": "production",
+        "deployment": "primary"
       },
       "annotations": {
         "descriptions": "Pod name ",
         "summary": "response_time_p90"
       },
-      "startsAt": "2021-11-26T10:57:14.057345112Z",
+      "startsAt": "2022-11-26T10:57:14.057345112Z",
       "endsAt": "0001-01-01T00:00:00Z",
       "generatorURL": "http://prometheus-server-6776d8bb7d-pqkln:9090/graph?g0.expr=histogram_quantile%280.9%2C+sum+by%28le%29+%28rate%28http_response_time_milliseconds_bucket%7Bhandler%3D%22ItemsController.addToCart%22%2Cjob%3D%22carts-sockshop-production-primary%22%7D%5B3m%5D%29%29%29+%3E+1000\\u0026g0.tab=1",
-      "fingerprint": "8dd2c31a47cf2e78"
+      "fingerprint": "add2c31a47cf2e78"
     }
   ],
   "groupLabels": {},

--- a/test/shipyard/podtatohead.deployment.yaml
+++ b/test/shipyard/podtatohead.deployment.yaml
@@ -22,3 +22,5 @@ spec:
           tasks:
             - name: "get-action"
             - name: "action"
+            - name: "evaluation"
+              triggeredAfter: "1m"


### PR DESCRIPTION
During testing I noticed that our remediation workflow never gets into an evaluation.triggered, unfortunately.

We end up getting an error message in Keptn's lighthouse-service like this:
```
ime="2022-08-29T12:15:49Z" level=error msg="Could not parse event payload: [json] found bytes \"{\"action\":{\"action\":\"scaling\",\"description\":\"Scale up\",\"name\":\"scaling\",\"value\":\"1\"},\"deployment\":\"primary\",\"evaluation\":{\"timeframe\":\"15m\"},\"get-action\":{\"actionIndex\":1},\"labels\":{\"Problem URL\":\"http://prometheus-server-57f4946cdb-fghkq:9090/graph?g0.expr=histogram_quantile%280.9%2C+sum+by%28le%29+%28rate%28http_response_time_milliseconds_bucket%7Bhandler%3D%22ItemsController.addToCart%22%2Cjob%3D%22carts-sockshop-production-primary%22%7D%5B3m%5D%29%29%29+%3E+1000\\u0026g0.tab=1\"},\"message\":\"\",\"problem\":{\"ImpactedEntity\":\"carts-primary\",\"PID\":\"\",\"ProblemDetails\":{\"problemDetails\":\"Pod name \"},\"ProblemID\":\"\",\"ProblemTitle\":\"response_time_p90\",\"ProblemURL\":\"http://prometheus-server-57f4946cdb-fghkq:9090/graph?g0.expr=histogram_quantile%280.9%2C+sum+by%28le%29+%28rate%28http_response_time_milliseconds_bucket%7Bhandler%3D%22ItemsController.addToCart%22%2Cjob%3D%22carts-sockshop-production-primary%22%7D%5B3m%5D%29%29%29+%3E+1000\\u0026g0.tab=1\",\"State\":\"OPEN\",\"labels\":{\"deployment\":\"primary\"},\"project\":\"sockshop\",\"service\":\"carts\",\"stage\":\"production\"},\"project\":\"sockshop\",\"result\":\"pass\",\"service\":\"carts\",\"stage\":\"production\",\"status\":\"succeeded\",\"temporaryData\":{\"distributor\":{\"subscriptionID\":\"d5596f2b-0f33-4fd2-a4c2-bb658f5ebe7b\"}}}\", but failed to unmarshal: json: cannot unmarshal string into Go struct field EvaluationTriggeredEventData.deployment of type v0_2_0.Deployment"
```

The root-cause of this is the `remediation.triggered` event which contains `"deployment": "primary"`, which is not compatible with lighthouse-service.
```
{
  "data": {
    "deployment": "primary", <------------ HERE
    "labels": {
      "Problem URL": "http://prometheus-server-6776d8bb7d-pqkln:9090/graph?g0.expr=histogram_quantile%280.9%2C+sum+by%28le%29+%28rate%28http_response_time_milliseconds_bucket%7Bhandler%3D%22ItemsController.addToCart%22%2Cjob%3D%22carts-sockshop-production-primary%22%7D%5B3m%5D%29%29%29+%3E+1000\\u0026g0.tab=1"
    },
    "problem": { ...
    }
  },
  "id": "8933f061-ff7e-4434-b4b4-ca2c0866825a",
  "shkeptncontext": "bdb4d1f9-cc6f-47a6-957b-620f28a2a873",
  "source": "prometheus",
  "specversion": "1.0",
  "time": "2022-08-29T14:12:41.783119566Z",
  "type": "sh.keptn.event.production.remediation.triggered"
}
```

This PR fixes it, and adapts the end-to-end test to detect this kind of thing.

# Proof that it works

Integration Test Run:https://github.com/keptn-contrib/prometheus-service/actions/runs/2949712155

Manual Run:
![image](https://user-images.githubusercontent.com/56065213/187234864-ff318f8a-2588-4667-a79f-39699f2f712e.png)
