### PR TITLE
chore: Update compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The *prometheus-service* is a [Keptn](https://keptn.sh) integration responsible 
 1. configuring Prometheus for monitoring services managed by Keptn,
 2. receiving alerts (on port 8080) from Prometheus Alertmanager and translating the alert payload to a cloud event (
    remediation.triggered) that is sent to the Keptn API,
-3. retrieving Service Level Indicators (SLIs) from a Prometheus API endpoint.
+3. retrieving Service Level Indicators (SLIs) from a Prometheus API endpoint and sending it back to Keptn.
 
 ## Compatibility Matrix
 
@@ -22,9 +22,9 @@ compatibility matrix below.
 |    0.14.2\**    |                                       keptncontrib/prometheus-service:0.8.0                                       |
 |     0.15.1      |                                     keptncontrib/prometheus-service:0.8.1\***                                     |
 |     0.16.0      |                                     keptncontrib/prometheus-service:0.8.2\***                                     |
-|     0.16.0      |                                       keptncontrib/prometheus-service:0.8.3                                       |
-|     0.17.0      |                                       keptncontrib/prometheus-service:0.8.5                                       |
-|   0.18.0\****   |                                       keptncontrib/prometheus-service:0.9.0                                       |
+|     0.16.x      |                                       keptncontrib/prometheus-service:0.8.3                                       |
+|     0.17.x      |                                       keptncontrib/prometheus-service:0.8.6                                       |
+|     0.18.x      |                                       keptncontrib/prometheus-service:0.9.1                                       |
 
 
 \* This is the Keptn version we aim to be compatible with. Other versions should work too, but there is no guarantee.
@@ -33,9 +33,6 @@ compatibility matrix below.
 change in NATS cluster name.
 
 \*** These versions are not compatible with Prometheus Alertmanager <= 0.24
-
-\**** This version is only compatible with Keptn 0.18.0 and potentially newer releases due to a breaking change with
-resource-service / configuration-service.
 
 You can find more information and older releases on
 the [Releases](https://github.com/keptn-contrib/prometheus-service/releases) page.


### PR DESCRIPTION
Update compatibility matrix to include the two latest releases: 0.9.1 and 0.8.6